### PR TITLE
Strip '*' characters at FASTA ingest time

### DIFF
--- a/src/plm_cluster/io_utils.py
+++ b/src/plm_cluster/io_utils.py
@@ -22,13 +22,13 @@ def read_fasta(path: str | Path) -> list[FastaRecord]:
                 continue
             if line.startswith(">"):
                 if rec_id is not None:
-                    records.append(FastaRecord(rec_id, "".join(seq_parts)))
+                    records.append(FastaRecord(rec_id, "".join(seq_parts).replace("*", "")))
                 rec_id = line[1:].split()[0]
                 seq_parts = []
             else:
                 seq_parts.append(line)
     if rec_id is not None:
-        records.append(FastaRecord(rec_id, "".join(seq_parts)))
+        records.append(FastaRecord(rec_id, "".join(seq_parts).replace("*", "")))
     return records
 
 

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from plm_cluster.io_utils import read_fasta
+
+
+def test_read_fasta_removes_stop_codons(tmp_path: Path):
+    fasta = tmp_path / "stop_codons.faa"
+    fasta.write_text(">p1\nMKT*AY*\n>p2\n*GAVLILKK*\n")
+
+    records = read_fasta(fasta)
+
+    assert [r.id for r in records] == ["p1", "p2"]
+    assert [r.seq for r in records] == ["MKTAY", "GAVLILKK"]


### PR DESCRIPTION
### Motivation

- Ensure sequences are sanitized as early as possible by removing `*` characters (commonly stop-codon markers) during FASTA ingestion so downstream code never sees them.

### Description

- Update `read_fasta` in `src/plm_cluster/io_utils.py` to remove all `"*"` characters from the assembled sequence when each FASTA record is finalized.
- Add `tests/test_io_utils.py` to verify that `read_fasta` strips `*` characters while preserving record IDs and ordering.

### Testing

- Ran `PYTHONPATH=src pytest -q tests/test_io_utils.py tests/test_pipeline.py tests/test_smoke.py` and the test suite passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa4d647cc483239dea6471e6b6a9de)